### PR TITLE
fix(okex): size long-position OCO TP/SL from base quantity, not quote value

### DIFF
--- a/pkg/exchange/okex/exchange.go
+++ b/pkg/exchange/okex/exchange.go
@@ -1216,7 +1216,10 @@ func (e *Exchange) PlaceTakeProfitAndStopLossOrder(ctx context.Context, position
 
 	if position.IsLong() {
 		orderReq.Side("sell")
-		orderReq.Sz(position.Market.FormatQuantity(position.Quote.Abs()))
+		// sz for the sell leg is in base currency; sizing it from the quote
+		// value oversells whenever |quote| > base (flipping the account into
+		// an unintended short) and undersells otherwise (leaving dust).
+		orderReq.Sz(position.Market.FormatQuantity(position.Base.Abs()))
 	} else if position.IsShort() {
 		orderReq.Side("buy")
 		orderReq.Sz(position.Market.FormatQuantity(position.Base.Abs()))


### PR DESCRIPTION
## Problem

`PlaceTakeProfitAndStopLossOrder` sizes the sell leg of a long position's OCO with `position.Quote.Abs()` — the quote-currency cost — while the short branch (and OKX itself, for the sell leg) uses **base units**:

```go
if position.IsLong() {
    orderReq.Side("sell")
    orderReq.Sz(position.Market.FormatQuantity(position.Quote.Abs()))  // quote value, wrong units
} else if position.IsShort() {
    orderReq.Side("buy")
    orderReq.Sz(position.Market.FormatQuantity(position.Base.Abs()))
}
```

Whenever `|quote|` diverges from `base` the resting algo order is mis-sized:
- `|quote| > base` → the SL/TP **oversells and flips the account into an unintended short**
- `|quote| < base` (typical when price < 1) → the close is partial and **leaves dust**

## Live evidence (SUIUSDT cross margin, trading-gpt v0.33.8)

- Dust position `base=2.4455, quote=-3.2501` had a resting OCO with `sz=3.2501` (= `|quote|`, exactly). Its SL leg market-sold 3.2501 SUI → net short `-0.8046` held ~22h. (yubing744/trading-gpt#95)
- Entry-time OCO for `base=54.8213, quote=-39.2804` was placed with `sz:39.2812` → the take-profit only closed 71% of the position; the remainder was later sold at a worse price. This is also the standing dust source reported in yubing744/trading-gpt#89.

The venue's interpretation of `sz` as base units for the sell leg is confirmed by the fills (the `sz=3.2501` order sold exactly 3.2501 SUI).

## Fix

Size the long branch from `position.Base.Abs()`, matching the short branch. Since `UpdatePosition` already cancels and re-places the OCO on every position update, correct sizing also removes the stale-resting-order path.

## Testing

`go build` / `go vet` / `go test ./pkg/exchange/okex/` pass (Go 1.21 toolchain).

Base branch is `issue73/okex-reduceonly` — the lineage currently pinned by trading-gpt's `libs/bbgo` submodule — so it can be picked up with a submodule bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)