### PR TITLE
fix(okex): handle channel-conn-count/notice control frames and proactively reconnect on 64008 service-upgrade

### DIFF
--- a/pkg/exchange/okex/parse.go
+++ b/pkg/exchange/okex/parse.go
@@ -103,7 +103,22 @@ const (
 	WsEventTypeError       = "error"
 	WsEventTypeSubscribe   = "subscribe"
 	WsEventTypeUnsubscribe = "unsubscribe"
+	// WsEventTypeChannelConnCount and WsEventTypeChannelConnCountError are informational
+	// control frames OKX pushes to report the number of connections per channel.
+	// See: https://www.okx.com/docs-v5/en/#websocket-api-connection-count-limit
+	WsEventTypeChannelConnCount      = "channel-conn-count"
+	WsEventTypeChannelConnCountError = "channel-conn-count-error"
+	// WsEventTypeNotice is a control frame OKX pushes to notify the client about connection
+	// lifecycle events, e.g. an upcoming service upgrade (code 64008).
+	WsEventTypeNotice = "notice"
 )
+
+// okexServiceUpgradeNoticeCode is the code carried by a `notice` event that OKX sends ~30s
+// before it proactively closes the connection for a service upgrade. When we see it we
+// reconnect ahead of the server-side close to avoid the gap otherwise caused by the
+// close(1006) + reconnect cool-down.
+// See: https://www.okx.com/docs-v5/en/#websocket-api-connection-count-limit
+const okexServiceUpgradeNoticeCode = "64008"
 
 type WebSocketEvent struct {
 	Event   WsEventType `json:"event"`
@@ -115,6 +130,13 @@ type WebSocketEvent struct {
 	} `json:"arg,omitempty"`
 	Data       json.RawMessage `json:"data"`
 	ActionType ActionType      `json:"action"`
+
+	// The following fields are only present on control frames such as
+	// `channel-conn-count`, `channel-conn-count-error` and `notice`.
+	// For these frames `channel` is at the top level rather than inside `arg`.
+	ConnCount string  `json:"connCount,omitempty"`
+	ConnId    string  `json:"connId,omitempty"`
+	ConnChan  Channel `json:"channel,omitempty"`
 }
 
 func (w *WebSocketEvent) IsValid() error {
@@ -123,6 +145,11 @@ func (w *WebSocketEvent) IsValid() error {
 		return fmt.Errorf("websocket request error, code: %s, msg: %s", w.Code, w.Message)
 
 	case WsEventTypeSubscribe, WsEventTypeUnsubscribe:
+		return nil
+
+	case WsEventTypeChannelConnCount, WsEventTypeChannelConnCountError, WsEventTypeNotice:
+		// Informational control frames. They are valid and handled (logged / acted on)
+		// in the stream dispatcher, not treated as errors.
 		return nil
 
 	case WsEventTypeLogin:
@@ -140,6 +167,13 @@ func (w *WebSocketEvent) IsValid() error {
 
 func (w *WebSocketEvent) IsAuthenticated() bool {
 	return w.Event == WsEventTypeLogin && w.Code == "0"
+}
+
+// IsServiceUpgradeNotice reports whether this event is the OKX pre-upgrade notice (code 64008),
+// which signals that the connection will soon be closed for a service upgrade and that the
+// client should reconnect proactively.
+func (w *WebSocketEvent) IsServiceUpgradeNotice() bool {
+	return w.Event == WsEventTypeNotice && w.Code == okexServiceUpgradeNoticeCode
 }
 
 type BookEvent struct {

--- a/pkg/exchange/okex/parse_test.go
+++ b/pkg/exchange/okex/parse_test.go
@@ -805,6 +805,7 @@ func TestWebSocketEvent_IsValid(t *testing.T) {
 			Event:   WsEventTypeLogin,
 			Code:    "0",
 			Message: "",
+			ConnId:  "a4d3ae55",
 		}, *opEvent)
 
 		assert.NoError(t, opEvent.IsValid())
@@ -825,6 +826,7 @@ func TestWebSocketEvent_IsValid(t *testing.T) {
 			Event:   WsEventTypeError,
 			Code:    "60009",
 			Message: "Login failed.",
+			ConnId:  "a4d3ae55",
 		}, *opEvent)
 
 		assert.ErrorContains(t, opEvent.IsValid(), "request error")
@@ -845,10 +847,114 @@ func TestWebSocketEvent_IsValid(t *testing.T) {
 			Event:   "test gg",
 			Code:    "60009",
 			Message: "unexpected",
+			ConnId:  "a4d3ae55",
 		}, *opEvent)
 
 		assert.ErrorContains(t, opEvent.IsValid(), "unexpected event type")
 	})
+
+	t.Run("channel-conn-count event", func(t *testing.T) {
+		input := `{
+  "event": "channel-conn-count",
+  "channel": "orders",
+  "connCount": "2",
+  "connId": "abcd1234"
+}`
+		res, err := parseWebSocketEvent([]byte(input))
+		assert.NoError(t, err)
+		opEvent, ok := res.(*WebSocketEvent)
+		assert.True(t, ok)
+		assert.Equal(t, WebSocketEvent{
+			Event:     WsEventTypeChannelConnCount,
+			ConnChan:  "orders",
+			ConnCount: "2",
+			ConnId:    "abcd1234",
+		}, *opEvent)
+
+		// It must be treated as a valid (non-error) control frame.
+		assert.NoError(t, opEvent.IsValid())
+		assert.False(t, opEvent.IsServiceUpgradeNotice())
+	})
+
+	t.Run("channel-conn-count-error event", func(t *testing.T) {
+		input := `{
+  "event": "channel-conn-count-error",
+  "channel": "orders",
+  "connCount": "20",
+  "connId": "a4d3ae55"
+}`
+		res, err := parseWebSocketEvent([]byte(input))
+		assert.NoError(t, err)
+		opEvent, ok := res.(*WebSocketEvent)
+		assert.True(t, ok)
+		assert.Equal(t, WebSocketEvent{
+			Event:     WsEventTypeChannelConnCountError,
+			ConnChan:  "orders",
+			ConnCount: "20",
+			ConnId:    "a4d3ae55",
+		}, *opEvent)
+
+		assert.NoError(t, opEvent.IsValid())
+		assert.False(t, opEvent.IsServiceUpgradeNotice())
+	})
+
+	t.Run("service upgrade notice event (64008)", func(t *testing.T) {
+		input := `{
+  "event": "notice",
+  "code": "64008",
+  "msg": "The connection will soon be closed for a service upgrade. Please reconnect.",
+  "connId": "a4d3ae55"
+}`
+		res, err := parseWebSocketEvent([]byte(input))
+		assert.NoError(t, err)
+		opEvent, ok := res.(*WebSocketEvent)
+		assert.True(t, ok)
+		assert.Equal(t, WebSocketEvent{
+			Event:   WsEventTypeNotice,
+			Code:    "64008",
+			Message: "The connection will soon be closed for a service upgrade. Please reconnect.",
+			ConnId:  "a4d3ae55",
+		}, *opEvent)
+
+		// It must be valid (not the invalid-event error branch) and must be recognized
+		// as the service-upgrade notice that triggers a proactive reconnect.
+		assert.NoError(t, opEvent.IsValid())
+		assert.True(t, opEvent.IsServiceUpgradeNotice())
+	})
+}
+
+func TestWebSocketEvent_IsServiceUpgradeNotice(t *testing.T) {
+	tests := []struct {
+		name  string
+		event WebSocketEvent
+		want  bool
+	}{
+		{
+			name:  "service upgrade notice (64008)",
+			event: WebSocketEvent{Event: WsEventTypeNotice, Code: "64008"},
+			want:  true,
+		},
+		{
+			name:  "notice with a different code",
+			event: WebSocketEvent{Event: WsEventTypeNotice, Code: "64009"},
+			want:  false,
+		},
+		{
+			name:  "64008 code but not a notice event",
+			event: WebSocketEvent{Event: WsEventTypeError, Code: "64008"},
+			want:  false,
+		},
+		{
+			name:  "unrelated event",
+			event: WebSocketEvent{Event: WsEventTypeSubscribe},
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.event.IsServiceUpgradeNotice())
+		})
+	}
 }
 
 func TestOrderTradeEvent(t *testing.T) {

--- a/pkg/exchange/okex/stream.go
+++ b/pkg/exchange/okex/stream.go
@@ -20,6 +20,12 @@ var (
 	// pingInterval the connection will break automatically if the subscription is not established or data has not been
 	// pushed for more than 30 seconds. Therefore, we set it to 20 seconds.
 	pingInterval = 20 * time.Second
+	// serviceUpgradeReconnectInterval throttles proactive reconnects triggered by OKX
+	// `notice` (code 64008) service-upgrade frames. OKX performs an upgrade roughly every
+	// 15-20 minutes and only sends the notice ~30s before closing, so at most one proactive
+	// reconnect per 30s window is required. This guards against a reconnect storm if the
+	// notice is delivered repeatedly.
+	serviceUpgradeReconnectInterval = 30 * time.Second
 )
 
 type WebsocketOp struct {
@@ -42,6 +48,11 @@ type Stream struct {
 	client          *okexapi.RestClient
 	balanceProvider types.ExchangeAccountService
 
+	// reconnectLimiter throttles proactive reconnects triggered by OKX service-upgrade
+	// notices. It is per-stream so the public and private streams throttle independently
+	// (each receives its own notice on its own connection).
+	reconnectLimiter *rate.Limiter
+
 	// public callbacks
 	kLineEventCallbacks       []func(candle KLineEvent)
 	bookEventCallbacks        []func(book BookEvent)
@@ -52,10 +63,11 @@ type Stream struct {
 
 func NewStream(client *okexapi.RestClient, balanceProvider types.ExchangeAccountService) *Stream {
 	stream := &Stream{
-		client:          client,
-		balanceProvider: balanceProvider,
-		StandardStream:  types.NewStandardStream(),
-		kLineStream:     NewKLineStream(),
+		client:           client,
+		balanceProvider:  balanceProvider,
+		StandardStream:   types.NewStandardStream(),
+		kLineStream:      NewKLineStream(),
+		reconnectLimiter: rate.NewLimiter(rate.Every(serviceUpgradeReconnectInterval), 1),
 	}
 
 	stream.SetParser(parseWebSocketEvent)
@@ -297,6 +309,19 @@ func (s *Stream) dispatchEvent(e interface{}) {
 			log.Errorf("invalid event: %v", err)
 			return
 		}
+
+		switch et.Event {
+		case WsEventTypeChannelConnCount, WsEventTypeChannelConnCountError:
+			log.Infof("okex channel connection count update: event=%s channel=%s connCount=%s connId=%s",
+				et.Event, et.ConnChan, et.ConnCount, et.ConnId)
+
+		case WsEventTypeNotice:
+			log.Infof("okex notice: code=%s msg=%q connId=%s", et.Code, et.Message, et.ConnId)
+			if et.IsServiceUpgradeNotice() {
+				s.handleServiceUpgradeNotice()
+			}
+		}
+
 		if et.IsAuthenticated() {
 			s.EmitAuth()
 		}
@@ -318,4 +343,30 @@ func (s *Stream) dispatchEvent(e interface{}) {
 		s.EmitMarketTradeEvent(et)
 
 	}
+}
+
+// handleServiceUpgradeNotice proactively reconnects the stream when OKX signals an upcoming
+// service upgrade (notice code 64008). OKX sends this ~30s before it force-closes the
+// connection (close 1006); reconnecting now lets the existing StandardStream reconnector
+// dial a fresh connection and re-subscribe ahead of the server-side close, avoiding the
+// kline gap that would otherwise appear during the post-close reconnect cool-down.
+//
+// This is safe against reconnect storms because:
+//   - StandardStream.Reconnect() only signals a buffered(1) channel with a non-blocking
+//     send, so repeated calls while a reconnect is already pending are coalesced/dropped.
+//   - reconnectLimiter additionally caps proactive reconnects to one per
+//     serviceUpgradeReconnectInterval, so a burst of notices cannot trigger repeated
+//     reconnects.
+//
+// It also does not conflict with the existing 20s ping keep-alive or handleConnect
+// re-subscription: those continue to run normally, and handleConnect performs the
+// re-subscription on the new connection this reconnect creates.
+func (s *Stream) handleServiceUpgradeNotice() {
+	if s.reconnectLimiter != nil && !s.reconnectLimiter.Allow() {
+		log.Warnf("okex service-upgrade notice (code %s) received but a proactive reconnect was already triggered recently; skipping to avoid reconnect storm", okexServiceUpgradeNoticeCode)
+		return
+	}
+
+	log.Warnf("okex service-upgrade notice (code %s) received; proactively reconnecting before the server closes the connection", okexServiceUpgradeNoticeCode)
+	s.Reconnect()
 }


### PR DESCRIPTION
## Root cause

OKX periodically (every ~15-20 min) upgrades its WebSocket service. Before doing so it pushes control frames on the connection:

- `channel-conn-count` / `channel-conn-count-error` — connection-count info frames
- `notice` with code **`64008`** — `"The connection will soon be closed for a service upgrade. Please reconnect."`, sent ~30s before the server-side close (`close 1006`)

The OKX adapter had two defects:

1. **Control frames spammed as errors.** `WebSocketEvent.IsValid()` only recognized `login/error/subscribe/unsubscribe`. `channel-conn-count` and `notice` fell into the default branch, so `dispatchEvent` logged them as `log.Errorf("invalid event: ...")` on every upgrade cycle.
2. **No proactive reconnect on 64008.** The `64008` notice was ignored, so OKX force-closed the connection (`close 1006`) and bbgo only reconnected afterwards — *after* the reconnect cool-down. This left a gap in which klines were dropped/delayed.

## Fix

**`pkg/exchange/okex/parse.go`**
- Recognize `channel-conn-count`, `channel-conn-count-error` and `notice` as valid control frames in `IsValid()` (return `nil` instead of the "unexpected event type" error).
- Parse the top-level `connCount` / `connId` / `channel` fields that these frames carry.
- Add `IsServiceUpgradeNotice()` → `true` when `event == "notice"` and `code == "64008"`.

**`pkg/exchange/okex/stream.go`**
- Log control frames at `info` level instead of `Errorf`.
- On a `64008` notice, proactively call `Reconnect()` so the existing `StandardStream` reconnector dials a fresh connection and re-subscribes **ahead of** the server-side close, closing the kline gap.

## Reconnect-storm safety (idempotent + throttled)

- `StandardStream.Reconnect()` only performs a **non-blocking send on a buffered(1) channel**, so repeated calls while a reconnect is already pending are coalesced/dropped.
- A **per-stream `rate.Limiter`** caps proactive reconnects to **one per 30s**, so a burst of notices cannot trigger repeated reconnects. It is per-stream so the public and private streams throttle independently (each receives its own notice on its own connection).
- Does **not** interfere with the existing 20s ping keep-alive or the `handleConnect` re-subscription (which runs on the newly-dialed connection).

## Tests

- `TestWebSocketEvent_IsValid`: added subtests for `channel-conn-count`, `channel-conn-count-error` and the `64008` notice frame (parse + `IsValid` + `IsServiceUpgradeNotice`).
- `TestWebSocketEvent_IsServiceUpgradeNotice`: table-driven coverage of the 64008 predicate (right code/wrong code/wrong event/unrelated event).
- Updated existing `IsValid` assertions to include the newly-parsed `connId`.

Results (`GOTOOLCHAIN=go1.22.0`):
- `go test ./pkg/exchange/okex/` → **PASS** (16 test functions, 0 fail)
- `go vet ./pkg/exchange/okex/...` → clean
- `go build ./pkg/exchange/okex/...` → OK

(The `pkg/exchange/okex/okexapi` package has pre-existing live-network integration tests that require reaching `www.okex.com`; those are unrelated to this change, which does not touch `okexapi`.)

Relates to yubing744/trading-gpt#90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)